### PR TITLE
Useful changes from separate project

### DIFF
--- a/pillar/tube_iptables/global.sls
+++ b/pillar/tube_iptables/global.sls
@@ -1,5 +1,6 @@
 {%- for minion, vars in salt.saltutil.runner('mine.get', tgt='tube_salt:enabled:True', fun='get_vars', tgt_type='pillar').items() %}
 firewall:
+  ipv6: True
   enabled: True
   install: True
   strict: True
@@ -9,4 +10,9 @@ firewall:
         - tcp
       ips_allow:
         - {{ vars.private_net }}.0/16
+        - {{ vars.public_net }}.0/0
+  services_ipv6:
+    ssh:
+      protos:
+        - tcp
 {%- endfor %}

--- a/pillar/tube_openldap/nginx_openldap.sls
+++ b/pillar/tube_openldap/nginx_openldap.sls
@@ -17,6 +17,10 @@ nginx:
             - access_log: /var/log/nginx/ldap.{{ vars.domain }}.access.log
             - error_log: /var/log/nginx/ldap.{{ vars.domain }}.error.log
 
+            - location /.well-known/acme-challenge/:
+              - default_type: "'text/plain'"
+              - root: /var/www/certbot
+
             - location /:
               - return: 301 https://$host$request_uri
 
@@ -76,6 +80,10 @@ nginx:
             - gzip: "on"
             - gzip_types: text/css application/javascript
             - gzip_vary: "on"
+
+            - location /.well-known/acme-challenge/:
+              - default_type: "'text/plain'"
+              - root: /var/www/certbot
 
             - location /:
               - proxy_read_timeout: 1200s

--- a/pillar/tube_openldap/nginx_openldap.sls
+++ b/pillar/tube_openldap/nginx_openldap.sls
@@ -38,8 +38,8 @@ nginx:
             - access_log: /var/log/nginx/ldap.{{ vars.domain }}.access.log
             - error_log: /var/log/nginx/ldap.{{ vars.domain }}.error.log
 
-            - ssl_certificate: /etc/ssl/private/tube_pki.crt
-            - ssl_certificate_key: /etc/ssl/private/tube_pki.key
+            - ssl_certificate: /etc/letsencrypt/live/www.{{ vars.domain }}/fullchain.pem
+            - ssl_certificate_key: /etc/letsencrypt/live/www.{{ vars.domain }}/privkey.pem
             - ssl_protocols: TLSv1.2
             - ssl_prefer_server_ciphers: "on"
             - ssl_ciphers: 'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256'
@@ -66,8 +66,8 @@ nginx:
             - access_log: /var/log/nginx/ldap.{{ vars.domain }}.access.log
             - error_log: /var/log/nginx/ldap.{{ vars.domain }}.error.log
 
-            - ssl_certificate: /etc/ssl/private/tube_pki.crt
-            - ssl_certificate_key: /etc/ssl/private/tube_pki.key
+            - ssl_certificate: /etc/letsencrypt/live/www.{{ vars.domain }}/fullchain.pem
+            - ssl_certificate_key: /etc/letsencrypt/live/www.{{ vars.domain }}/privkey.pem
             - ssl_protocols: TLSv1.2
             - ssl_prefer_server_ciphers: "on"
             - ssl_ciphers: 'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256'

--- a/pillar/tube_openldap/nginx_openldap.sls
+++ b/pillar/tube_openldap/nginx_openldap.sls
@@ -25,7 +25,7 @@ nginx:
               - return: 301 https://$host$request_uri
 
       https_www.ldap.{{ vars.domain }}:
-        enabled: True
+        enabled: False # Set to false for the initial run; Once certbot certs are configured, then set to True
         config:
           - server:
             - server_name:
@@ -53,7 +53,7 @@ nginx:
               - return: 301 https://ldap.{{ vars.domain }}$request_uri
 
       https_ldap.{{ vars.domain }}:
-        enabled: True
+        enabled: False # Set to false for the initial run; Once certbot certs are configured, then set to True
         config:
           - server:
             - server_name:

--- a/pillar/tube_openldap/nginx_self_service_password.sls
+++ b/pillar/tube_openldap/nginx_self_service_password.sls
@@ -25,7 +25,7 @@ nginx:
               - return: 301 https://$host$request_uri
 
       https_www.password.{{ vars.domain }}:
-        enabled: True
+        enabled: False # Set to false for the initial run; Once certbot certs are configured, then set to True
         config:
           - server:
             - server_name:
@@ -53,7 +53,7 @@ nginx:
               - return: 301 https://password.{{ vars.domain }}$request_uri
 
       https_password.{{ vars.domain }}:
-        enabled: True
+        enabled: False # Set to false for the initial run; Once certbot certs are configured, then set to True
         config:
           - server:
             - server_name:

--- a/pillar/tube_openldap/nginx_self_service_password.sls
+++ b/pillar/tube_openldap/nginx_self_service_password.sls
@@ -17,6 +17,10 @@ nginx:
             - access_log: /var/log/nginx/password.{{ vars.domain }}.access.log
             - error_log: /var/log/nginx/password.{{ vars.domain }}.error.log
 
+            - location /.well-known/acme-challenge/:
+              - default_type: "'text/plain'"
+              - root: /var/www/certbot
+
             - location /:
               - return: 301 https://$host$request_uri
 
@@ -76,6 +80,10 @@ nginx:
             - gzip: "on"
             - gzip_types: text/css application/javascript
             - gzip_vary: "on"
+
+            - location /.well-known/acme-challenge/:
+              - default_type: "'text/plain'"
+              - root: /var/www/certbot
 
             - location /:
               - proxy_read_timeout: 1200s

--- a/pillar/tube_openldap/nginx_self_service_password.sls
+++ b/pillar/tube_openldap/nginx_self_service_password.sls
@@ -38,8 +38,8 @@ nginx:
             - access_log: /var/log/nginx/password.{{ vars.domain }}.access.log
             - error_log: /var/log/nginx/password.{{ vars.domain }}.error.log
 
-            - ssl_certificate: /etc/ssl/private/tube_pki.crt
-            - ssl_certificate_key: /etc/ssl/private/tube_pki.key
+            - ssl_certificate: /etc/letsencrypt/live/www.{{ vars.domain }}/fullchain.pem
+            - ssl_certificate_key: /etc/letsencrypt/live/www.{{ vars.domain }}/privkey.pem
             - ssl_protocols: TLSv1.2
             - ssl_prefer_server_ciphers: "on"
             - ssl_ciphers: 'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256'
@@ -66,8 +66,8 @@ nginx:
             - access_log: /var/log/nginx/password.{{ vars.domain }}.access.log
             - error_log: /var/log/nginx/password.{{ vars.domain }}.error.log
 
-            - ssl_certificate: /etc/ssl/private/tube_pki.crt
-            - ssl_certificate_key: /etc/ssl/private/tube_pki.key
+            - ssl_certificate: /etc/letsencrypt/live/www.{{ vars.domain }}/fullchain.pem
+            - ssl_certificate_key: /etc/letsencrypt/live/www.{{ vars.domain }}/privkey.pem
             - ssl_protocols: TLSv1.2
             - ssl_prefer_server_ciphers: "on"
             - ssl_ciphers: 'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256'

--- a/pillar/tube_peertube/iptables.sls
+++ b/pillar/tube_peertube/iptables.sls
@@ -1,14 +1,22 @@
 {%- for minion, vars in salt.saltutil.runner('mine.get', tgt='tube_salt:enabled:True', fun='get_vars', tgt_type='pillar').items() %}
 firewall:
+  ipv6: True
   services:
     80:
       protos:
         - tcp
       ips_allow:
-        - 0.0.0.0/0
+        - {{ vars.public_net }}.0/0
     443:
       protos:
         - tcp
       ips_allow:
-        - 0.0.0.0/0
+        - {{ vars.public_net }}.0/0
+  services_ipv6:
+    80:
+      protos:
+        - tcp
+    443:
+      protos:
+        - tcp
 {%- endfor %}

--- a/pillar/tube_peertube/letsencrypt.sls
+++ b/pillar/tube_peertube/letsencrypt.sls
@@ -14,6 +14,12 @@ letsencrypt:
     www:
       - www.{{ vars.domain }}
       - {{ vars.domain }}
+      - www.ldap.{{ vars.domain }}
+      - ldap.{{ vars.domain }}
+      - www.password.{{ vars.domain }}
+      - password.{{ vars.domain }}
+      - www.rundeck.{{ vars.domain }}
+      - rundeck.{{ vars.domain }}
   post_renew:
     cmds:
       - systemctl restart nginx

--- a/pillar/tube_rundeck/nginx_rundeck.sls
+++ b/pillar/tube_rundeck/nginx_rundeck.sls
@@ -38,8 +38,8 @@ nginx:
             - access_log: /var/log/nginx/rundeck.{{ vars.domain }}.access.log
             - error_log: /var/log/nginx/rundeck.{{ vars.domain }}.error.log
 
-            - ssl_certificate: /etc/ssl/private/tube_pki.crt
-            - ssl_certificate_key: /etc/ssl/private/tube_pki.key
+            - ssl_certificate: /etc/letsencrypt/live/www.{{ vars.domain }}/fullchain.pem
+            - ssl_certificate_key: /etc/letsencrypt/live/www.{{ vars.domain }}/privkey.pem
             - ssl_protocols: TLSv1.2
             - ssl_prefer_server_ciphers: "on"
             - ssl_ciphers: 'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256'
@@ -66,8 +66,8 @@ nginx:
             - access_log: /var/log/nginx/rundeck.{{ vars.domain }}.access.log
             - error_log: /var/log/nginx/rundeck.{{ vars.domain }}.error.log
 
-            - ssl_certificate: /etc/ssl/private/tube_pki.crt
-            - ssl_certificate_key: /etc/ssl/private/tube_pki.key
+            - ssl_certificate: /etc/letsencrypt/live/www.{{ vars.domain }}/fullchain.pem
+            - ssl_certificate_key: /etc/letsencrypt/live/www.{{ vars.domain }}/privkey.pem
             - ssl_protocols: TLSv1.2
             - ssl_prefer_server_ciphers: "on"
             - ssl_ciphers: 'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256'

--- a/pillar/tube_rundeck/nginx_rundeck.sls
+++ b/pillar/tube_rundeck/nginx_rundeck.sls
@@ -25,7 +25,7 @@ nginx:
               - return: 301 https://$host$request_uri
 
       https_www.rundeck.{{ vars.domain }}:
-        enabled: True
+        enabled: False # Set to false for the initial run; Once certbot certs are configured, then set to True
         config:
           - server:
             - server_name:
@@ -53,7 +53,7 @@ nginx:
               - return: 301 https://rundeck.{{ vars.domain }}$request_uri
 
       https_rundeck.{{ vars.domain }}:
-        enabled: True
+        enabled: # Set to false for the initial run; Once certbot certs are configured, then set to True
         config:
           - server:
             - server_name:

--- a/pillar/tube_rundeck/nginx_rundeck.sls
+++ b/pillar/tube_rundeck/nginx_rundeck.sls
@@ -17,6 +17,10 @@ nginx:
             - access_log: /var/log/nginx/rundeck.{{ vars.domain }}.access.log
             - error_log: /var/log/nginx/rundeck.{{ vars.domain }}.error.log
 
+            - location /.well-known/acme-challenge/:
+              - default_type: "'text/plain'"
+              - root: /var/www/certbot
+
             - location /:
               - return: 301 https://$host$request_uri
 
@@ -76,6 +80,10 @@ nginx:
             - gzip: "on"
             - gzip_types: text/css application/javascript
             - gzip_vary: "on"
+
+            - location /.well-known/acme-challenge/:
+              - default_type: "'text/plain'"
+              - root: /var/www/certbot
 
             - location /:
               - proxy_read_timeout: 1200s

--- a/salt/tube_iptables/init.sls
+++ b/salt/tube_iptables/init.sls
@@ -1,4 +1,5 @@
 include:
   - iptables
   - tube_iptables.icmp
+  - tube_iptables.linode
   - tube_iptables.restart

--- a/salt/tube_iptables/linode.sls
+++ b/salt/tube_iptables/linode.sls
@@ -1,0 +1,43 @@
+router_advertisement:
+  iptables.append:
+    - chain: INPUT
+    - family: ipv6
+    - protocol: icmpv6
+    - icmpv6-type: router-advertisement
+    - match: hl
+    - hl-eq: 255
+    - jump: ACCEPT
+    - save: true
+
+neighbor_solicitation:
+  iptables.append:
+    - chain: INPUT
+    - family: ipv6
+    - protocol: icmpv6
+    - icmpv6-type: neighbor-solicitation
+    - match: hl
+    - hl-eq: 255
+    - jump: ACCEPT
+    - save: true
+
+neighbor_advertisement:
+  iptables.append:
+    - chain: INPUT
+    - family: ipv6
+    - protocol: icmpv6
+    - icmpv6-type: neighbor-advertisement
+    - match: hl
+    - hl-eq: 255
+    - jump: ACCEPT
+    - save: true
+
+redirect:
+  iptables.append:
+    - chain: INPUT
+    - family: ipv6
+    - protocol: icmpv6
+    - icmpv6-type: redirect
+    - match: hl
+    - hl-eq: 255
+    - jump: ACCEPT
+    - save: true

--- a/salt/tube_openldap/groups.sls
+++ b/salt/tube_openldap/groups.sls
@@ -23,7 +23,7 @@ manage_tube_login_groups:
             member:
               - cn=tube_system,ou=Users,{{ pillar.openldap.base }}
             description:
-              - Group for LDAP Administration rights
+              - Add users to this group if they need to be able to modify existing users and groups. USERS IN THIS GROUP CANNOT CREATE/DELETE USERS OR GROUPS.
       - 'cn=tube_users,ou=Groups,{{ pillar.openldap.base }}':
         - add:
             cn:
@@ -46,7 +46,7 @@ manage_tube_login_groups:
             memberUid:
               - tube_system
             description:
-              - Sudoers; Add users to this group if they should have sudoers access to linux
+              - Add users to this group if they should have ROOT access to the linux servers.
       - 'cn=tube_peertube,ou=Groups,{{ pillar.openldap.base }}':
         - add:
             cn:
@@ -59,7 +59,7 @@ manage_tube_login_groups:
             memberUid:
               - tube_system
             description:
-              - Sudoers; Add users to this group if they should have access to the peertube group
+              - Add users to this group if they should have access to the peertube site files.
       - 'cn=tube_linux,ou=Groups,{{ pillar.openldap.base }}':
         - add:
             cn:
@@ -70,7 +70,7 @@ manage_tube_login_groups:
             member:
               - cn=tube_system,ou=Users,{{ pillar.openldap.base }}
             description:
-              - Group for Linux Access; Add users to sudo if they should also have sudoers access
+              - Add users to this group if they should be able to log into the linux servers. This is useful for SFTP or SSH access.
       - 'cn=rundeck_admin,ou=Groups,{{ pillar.openldap.base }}':
         - add:
             cn:
@@ -81,7 +81,7 @@ manage_tube_login_groups:
             member:
               - cn={{ pillar.openldap.secrets.rundeck_admin_user }},ou=Users,{{ pillar.openldap.base }}
             description:
-              - Group for Rundeck Admins
+              - Group for Rundeck Admins.
 {%- for minion, projects in salt['mine.get']('tube_rundeck:enabled:True', fun='get_rundeck_projects', tgt_type='pillar').iteritems() %}
   {%- if projects is defined %}
     {%- for project, args in projects.items() %}
@@ -96,7 +96,7 @@ manage_tube_login_groups:
             member:
               - cn={{ pillar.openldap.secrets.rundeck_admin_user }},ou=Users,{{ pillar.openldap.base }}
             description:
-              - Group for access to the {{ project }} project
+              - Group for access to the {{ project }} Rundeck project.
         {% do existing_groups.append(project) %}
       {%- endif %}
     {%- endfor %}

--- a/salt/tube_openldap/groups.sls
+++ b/salt/tube_openldap/groups.sls
@@ -47,6 +47,19 @@ manage_tube_login_groups:
               - tube_system
             description:
               - Sudoers; Add users to this group if they should have sudoers access to linux
+      - 'cn=tube_peertube,ou=Groups,{{ pillar.openldap.base }}':
+        - add:
+            cn:
+              - peertube
+              - tube_peertube
+            objectClass:
+              - top
+              - posixGroup
+            gidNumber: 9202
+            memberUid:
+              - tube_system
+            description:
+              - Sudoers; Add users to this group if they should have access to the peertube group
       - 'cn=tube_linux,ou=Groups,{{ pillar.openldap.base }}':
         - add:
             cn:

--- a/salt/tube_peertube/install.sls
+++ b/salt/tube_peertube/install.sls
@@ -1,3 +1,6 @@
+{% set version = "v1.3.1" %}
+{% set hash = "20957d28c8758759d97c61f82f9baaabf8cb1dbce2c43b4c97792b75dd40ec23" %}
+
 /var/www/peertube/config:
   file.directory:
     - user: peertube
@@ -16,13 +19,13 @@
   file.directory:
     - user: peertube
     - group: www-data
-    - dir_mode: 0750
+    - dir_mode: 0755
     - makedirs: True
 
 /var/www/peertube/versions/:
   archive.extracted:
-    - source: https://github.com/Chocobozzz/PeerTube/releases/download/v1.3.1/peertube-v1.3.1.zip
-    - source_hash: 20957d28c8758759d97c61f82f9baaabf8cb1dbce2c43b4c97792b75dd40ec23
+    - source: https://github.com/Chocobozzz/PeerTube/releases/download/{{ version }}/peertube-{{ version }}.zip
+    - source_hash: {{ hash }}
     - archive_format: zip
     - user: peertube
     - group: peertube
@@ -31,7 +34,7 @@
 
 /var/www/peertube/peertube-latest:
   file.symlink:
-    - target: /var/www/peertube/versions/peertube-v1.3.1
+    - target: /var/www/peertube/versions/peertube-{{ version }}
     - user: peertube
     - group: www-data
     - makedirs: True
@@ -43,3 +46,33 @@ install_peertube:
     - cwd: /var/www/peertube/peertube-latest
     - runas: peertube
     - name: yarn install --production --pure-lockfile
+
+/var/www/peertube/versions/peertube-{{ version }}/client/dist/en_US:
+  file.directory:
+    - user: peertube
+    - group: peertube
+    - dir_mode: 0775
+    - require:
+      - cmd: install_peertube
+  cmd.run:
+    - name: find /var/www/peertube/versions/peertube-{{ version }}/client/dist/en_US -type f -exec chmod 0664 {} \;
+    - runas: root
+    - require:
+      - cmd: install_peertube
+
+/var/www/peertube/versions/peertube-{{ version }}/client/dist/assets/images:
+  file.directory:
+    - user: peertube
+    - group: peertube
+    - dir_mode: 0775
+    - recurse:
+      - user
+      - group
+      - mode
+    - require:
+      - cmd: install_peertube
+  cmd.run:
+    - name: find /var/www/peertube/versions/peertube-{{ version }}/client/dist/assets/images -type f -exec chmod 0664 {} \;
+    - runas: root
+    - require:
+      - cmd: install_peertube

--- a/salt/tube_peertube/users.sls
+++ b/salt/tube_peertube/users.sls
@@ -6,7 +6,6 @@ peertube_group:
 peertube:
   user.present:
     - shell: /bin/bash
-    - home: /var/www/peertube
     - uid: 9202
     - allow_uid_change: true
     - allow_gid_change: true


### PR DESCRIPTION
Based on actual production experience, I've included these useful changes:

- Do not assign a home dir to the peertube user. Let it get set by default.
- When creating letsencrypt certificates, include the tool domains too. More convenient for end users and just as easy to do.
- Create an LDAP group to allow access to peertube site files. Users have to be given the tube_linux and tube_peertube groups for this to work, and then they can access these files via SFTP or SSH.
- Open up port 22 for both servers. 
- Properly enable IPv6 based firewall, and make sure that icmpv6 packets (needed to route the address) are enabled as well.
- Ensure that https is disabled by default so that first run will work.
- Put in better LDAP group descriptions.